### PR TITLE
fix : 스터디 모집글 작성/수정 페이지 모달창 배경 클릭 시 닫힘 처리

### DIFF
--- a/src/app/write/components/SelectDate.tsx
+++ b/src/app/write/components/SelectDate.tsx
@@ -42,7 +42,7 @@ const SelectDate = (props: Props) => {
   const handleScroll = (e: React.UIEvent<HTMLDivElement>, type: string) => {
     const container = e.currentTarget;
     const index = Math.round(container.scrollTop / 40);
-    
+
     switch (type) {
       case "year":
         setYear(yearOption[index]);
@@ -67,7 +67,7 @@ const SelectDate = (props: Props) => {
   return props.mode === "date" ? (
     <SelectDateModal
       handleClose={props.onClose}
-      handleConfirm={() => props.onConfirm(`${year}-${month}-${day}`)}
+      handleConfirm={() => props.onConfirm(`${year}년 ${month}월 ${day}일`)}
       selectedDate={`${year}년 ${month}월 ${day}일`}
     >
       {/* 년 선택 */}

--- a/src/app/write/components/StudyModal.tsx
+++ b/src/app/write/components/StudyModal.tsx
@@ -39,24 +39,24 @@ const StudyModal = (props: ModalProps) => {
           <>
             <Image src={Warning} alt="union" width={0} className="mb-6" />
             <h3 className="title-20-s mb-3 text-center">
-              모집글을 작성할<br></br> 스터디 그룹이 없어요
+              모집글을 작성할<br></br>스터디 그룹이 없어요
             </h3>
             <p className="body-14-m mb-4 text-center text-gray-700">
               지금 바로 스터디를 만드시겠습니까?
             </p>
-            <div className="flex justify-center">
+            <div className="body-16-s m-4 flex w-full justify-center">
               <button
                 onClick={props.onClose}
                 className="... ml-1 flex w-2/6 items-center justify-center rounded-full border border-black text-center text-lg text-black"
               >
                 취소
               </button>
-              <button
-                onClick={props.onConfirm}
+              <Link
+                href="/write/study"
                 className="... ... ml-1 flex size-14 w-4/6 items-center justify-center rounded-full bg-secondary-900 text-center text-lg text-white"
               >
-                바로 가기
-              </button>
+                스터디 만들기
+              </Link>
             </div>
           </>
         ) : props.modalMode === "close" ? (

--- a/src/app/write/components/WriteModal.tsx
+++ b/src/app/write/components/WriteModal.tsx
@@ -47,9 +47,10 @@ const WriteModal = (props: ModalProps) => {
         </div>
       </div>
     ) : (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center w-full z-50">
-        <div className="fixed inset-x-0 bottom-0 bg-white rounded-t-2xl w-full shadow-lg flex flex-col h-2/5 overflow-y-auto focus:overscroll-contain p-5">
-          <h1 className="title-20-m ">스터디 그룹 선택</h1>
+      <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center w-full z-50" onClick={props.onClose}>
+        <div className="fixed inset-x-0 bottom-0 bg-white rounded-t-2xl w-full shadow-lg flex flex-col h-2/5 overflow-y-auto focus:overscroll-contain p-5" 
+        onClick={(e) => e.stopPropagation()}>
+          <h1 className="title-20-m">스터디 그룹 선택</h1>
           <p className="body-14-m text-secondary-400 pt-2">
             모집글을 작성할 스터디 그룹을 선택해주세요.
           </p>

--- a/src/app/write/page.tsx
+++ b/src/app/write/page.tsx
@@ -188,7 +188,7 @@ function WriteContent() {
           <input
             className="body-16-m my-3 w-full rounded-2xl bg-secondary-50 p-3 placeholder-secondary-300"
             value={title}
-            maxLength={20}
+            maxLength={25}
             onChange={(e) => setTitle(e.target.value)}
             placeholder="제목을 작성해주세요"
           />

--- a/src/app/write/study/page.tsx
+++ b/src/app/write/study/page.tsx
@@ -62,8 +62,12 @@ function StudyContent() {
         url,
       ),
     onSuccess: () => {
-      setModalMode("success");
-      setIsModalOpen(true);
+      if (userCnt === 1) {
+        router.replace("/");
+      } else {
+        setModalMode("success");
+        setIsModalOpen(true);
+      }
     },
     onError: () => {
       alert("스터디를 생성하지 못했습니다.");
@@ -181,6 +185,7 @@ function StudyContent() {
         <input
           className="body-16-m mb-4 w-full rounded-2xl bg-secondary-50 p-3 placeholder-secondary-300"
           value={title}
+          maxLength={25}
           onChange={(e) => setTitle(e.target.value)}
           placeholder="제목을 작성해주세요"
         />

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -50,6 +50,9 @@ const Modal = (props: Props) => {
       >
         <div className="flex flex-col justify-center w-full p-5">
           <h1 className="title-20-m">
+          {props.modalMode === "job" 
+              ? "직업 태그 선택"
+              : "스터디 태그 선택"}
           </h1>
           <p className="body-16-m text-secondary-400 pt-2">
             {props.modalMode === "job" 

--- a/src/components/common/SelectDateModal.tsx
+++ b/src/components/common/SelectDateModal.tsx
@@ -29,12 +29,6 @@ const SelectDateModal = ({
         </section>
         <div className="flex justify-center items-center gap-2 text-white mt-4 border-t py-[10px] px-6">
           <button
-            onClick={handleClose}
-            className="flex-1 px-4 py-2 rounded-3xl border border-secondary-900 bg-white body-16-s text-secondary-900"
-          >
-            취소하기
-          </button>
-          <button
             onClick={handleConfirm}
             className="flex-1 px-4 py-2 rounded-3xl bg-secondary-900 body-16-s text-white"
           >


### PR DESCRIPTION
## ✅ 작업 사항

fix : 1차 발표 후 에러 사항 수정 중

## 📌 변경 사항

에러 수정 & 개선 사항 정리 
1. 스터디 생성 페이지 css 수정 
2. 드롭다운 css 수정 
3. 모집글 생성, 수정 페이지 css 수정 
4. 스터디 그룹페이지 css 수정 
5. 카테고리 선택하는 Bottom Sheet - Background 배경 클릭 시 닫히도록
6. DropDown 클릭 후 뒷 배경 누를 시 드롭다운 메뉴 닫히도록  + DropDown 클릭 했을 때 
스크롤 맨위로 가지않도록 
7. 이미지 선택하는거 한번에 안됨 ? 
8. 이미지 바꾸는거 안됐다가 됐다가 안됐다가 함 ?
9. 인원 선택 16명 초과 undefind없도록 
10. 인원 숫자 선택 10의 자리수랑 1의 자리수랑 따로 분리
11. 취소하기 버튼 없애기 ㅇ
12. 글쓰기나 필수칸 비어있어도 모집글 생성이나, 스터디 글 생성 
13. 스터디 수정 페이지 기능 구현 
14. 모달창 로직 재수정 
15. 시작 예정일 취소하기 ㅇ
16. 시작 예정일 년 월 일 로 표시 ㅇ
17. 스터디 그룹 bottom sheet 동일하게
18. 필수 항목 칸 안채웠는데 작성 되는 문제 
19. 모집글 페이지 취업준비생, 기타 자격증 글씨 긴거 골랐을때 다 카드안에 들어가도록 
20. 이미지 업로드하는 곳 업로드시 cover로 동일하게 정사각형으로 표시되도록 
21. 스터디가 없어요 모달에서 바로가기 클릭하면 , 모집글 작성 모달이 나온다? ㅇ
22.  스터디 만들기 완료 버튼 두번씩 안눌리도록 - 모집글 마찬가지 
23. 텍스트 필드 포커스 일때 테두리 검은색인거 다 동일? 
24. 스터디 만들 때 기본 이미지 만들기 
25. 글자 수 제한 모집글 내용 500 자 제목 25자 ㅇ
26. 필수 사항 선택 안하고 체크 버튼 누르면 선택 안된 필수 사항 빨간 테두리로 바뀌도록 
27. 혼자 일 때도 프로필 가운데로 오도록 , 프로필 로딩 빠르게 
28. 직업 태그, 카테고리 태그 눌렀을 떄 로딩이 늦음 성능적으로 개선 
29. 전반적인 이미지 태그에 대해서 로딩 느림 늦은거 성능적으로 개선 필요 
30. 1인 스터디 생성 시 모집글 작성하시겠습니까 안뜨도록 ㅇ

## 🧑‍💻 기타

-
-
